### PR TITLE
fix: 商家任务配置细化，接口更新，商家积分任务更新

### DIFF
--- a/app/src/main/java/fansirsqi/xposed/sesame/task/antMember/AntMemberRpcCall.java
+++ b/app/src/main/java/fansirsqi/xposed/sesame/task/antMember/AntMemberRpcCall.java
@@ -38,9 +38,25 @@ public class AntMemberRpcCall {
                 "[{\"autoSignIn\":true,\"invitorUserId\":\"\",\"sceneCode\":\"QUERY\"}]");
     }
 
+    /* 商家开门打卡任务 */
+    public static String signIn(String activityNo) {
+        return RequestManager.requestString("alipay.merchant.kmdk.signIn",
+                "[{\"activityNo\":\"" + activityNo + "\"}]");
+    }
+
+    public static String signUp(String activityNo) {
+        return RequestManager.requestString("alipay.merchant.kmdk.signUp",
+                "[{\"activityNo\":\"" + activityNo + "\"}]");
+    }
+
     /* 商家服务 */
     public static String transcodeCheck() {
         return RequestManager.requestString("alipay.mrchservbase.mrchbusiness.sign.transcode.check",
+                "[{}]");
+    }
+
+    public static String merchantSign() {
+        return RequestManager.requestString("alipay.mrchservbase.mrchpoint.sqyj.homepage.signin.v1",
                 "[{}]");
     }
 
@@ -55,23 +71,13 @@ public class AntMemberRpcCall {
     }
 
     public static String taskListQuery() {
-        return RequestManager.requestString("alipay.mrchservbase.zcj.taskList.query",
-                "[{\"compId\":\"ZCJ_TASK_LIST\",\"params\":{\"activityCode\":\"ZCJ\",\"clientVersion\":\"10.3.36\",\"extInfo\":{},\"platform\":\"Android\",\"underTakeTaskCode\":\"\"}}]");
+        return RequestManager.requestString("alipay.mrchservbase.task.more.query",
+                "[{\"paramMap\":{\"platform\":\"Android\"},\"taskItemCode\":\"\"}]");
     }
 
     public static String queryActivity() {
         return RequestManager.requestString("alipay.merchant.kmdk.query.activity",
                 "[{\"scene\":\"activityCenter\"}]");
-    }
-
-    public static String signIn(String activityNo) {
-        return RequestManager.requestString("alipay.merchant.kmdk.signIn",
-                "[{\"activityNo\":\"" + activityNo + "\"}]");
-    }
-
-    public static String signUp(String activityNo) {
-        return RequestManager.requestString("alipay.merchant.kmdk.signUp",
-                "[{\"activityNo\":\"" + activityNo + "\"}]");
     }
 
     /* 商家服务任务 */


### PR DESCRIPTION
- 移除招财金相关内容，改为商家服务签到
- 商家服务接口更新
- 商家服务任务细化：**商家服务签到、商家服务开门打卡、商家服务积分任务**
- 商家服务积分任务新增：**逛一逛商品橱窗、逛一逛得缴费红包、逛一逛支付宝会员、逛一逛支付宝亲情卡、逛逛领优惠得红包、去饿了么果园0元领水果、去逛逛芝麻攒粒攻略、逛信用卡频道得优惠、去淘宝芭芭农场领水果百货**
- 商家服务积分失效任务移除
- 商家服务积分任务添加执行延时16s