### PR TITLE
修复了一些Bug，可能又加了一些Bug（不是）

### DIFF
--- a/app/src/main/java/fansirsqi/xposed/sesame/hook/ApplicationHook.java
+++ b/app/src/main/java/fansirsqi/xposed/sesame/hook/ApplicationHook.java
@@ -542,7 +542,7 @@ public class ApplicationHook implements IXposedHookLoadPackage {
                 if (!Model.getModel(BaseModel.class).getEnableField().getValue()) {
                     Log.record("芝麻粒已禁用");
                     Toast.show("芝麻粒已禁用");
-                    Notify.updateStatusText("🚫芝麻粒已禁用");
+                    Notify.setStatusTextDisabled();
                     return false;
                 }
                 // 保持唤醒锁，防止设备休眠
@@ -708,8 +708,6 @@ public class ApplicationHook implements IXposedHookLoadPackage {
     }
 
     static void execHandler() {
-        Log.debug("execHandler");
-        Notify.setStatusTextExec();
         mainTask.startTask(false);
     }
 

--- a/app/src/main/java/fansirsqi/xposed/sesame/hook/ApplicationHook.java
+++ b/app/src/main/java/fansirsqi/xposed/sesame/hook/ApplicationHook.java
@@ -538,9 +538,11 @@ public class ApplicationHook implements IXposedHookLoadPackage {
                             },
                             2000);
                 }
+                Notify.start(service);
                 if (!Model.getModel(BaseModel.class).getEnableField().getValue()) {
                     Log.record("芝麻粒已禁用");
                     Toast.show("芝麻粒已禁用");
+                    Notify.updateStatusText("🚫芝麻粒已禁用");
                     return false;
                 }
                 // 保持唤醒锁，防止设备休眠

--- a/app/src/main/java/fansirsqi/xposed/sesame/hook/ApplicationHook.java
+++ b/app/src/main/java/fansirsqi/xposed/sesame/hook/ApplicationHook.java
@@ -643,7 +643,6 @@ public class ApplicationHook implements IXposedHookLoadPackage {
                         Log.printStackTrace(TAG, t);
                     }
                 }
-                Notify.start(service);
                 Model.bootAllModel(classLoader);
                 StatusUtil.load();
                 updateDay();
@@ -709,6 +708,8 @@ public class ApplicationHook implements IXposedHookLoadPackage {
     }
 
     static void execHandler() {
+        Log.debug("execHandler");
+        Notify.setStatusTextExec();
         mainTask.startTask(false);
     }
 

--- a/app/src/main/java/fansirsqi/xposed/sesame/hook/ApplicationHook.java
+++ b/app/src/main/java/fansirsqi/xposed/sesame/hook/ApplicationHook.java
@@ -540,8 +540,8 @@ public class ApplicationHook implements IXposedHookLoadPackage {
                             },
                             2000);
                 }
+                Notify.start(service);
                 if (!Objects.requireNonNull(Model.getModel(BaseModel.class)).getEnableField().getValue()) {
-                    Notify.start(service);
                     Log.record("芝麻粒已禁用");
                     Toast.show("芝麻粒已禁用");
                     Notify.setStatusTextDisabled();

--- a/app/src/main/java/fansirsqi/xposed/sesame/model/BaseModel.java
+++ b/app/src/main/java/fansirsqi/xposed/sesame/model/BaseModel.java
@@ -141,6 +141,12 @@ public class BaseModel extends Model {
     @Getter
     private static final BooleanModelField enableOnGoing = new BooleanModelField("enableOnGoing", "开启状态栏禁删", false);
 
+    /**
+     * 是否开启任务运行进度显示
+     */
+    @Getter
+    private static final BooleanModelField enableProgress = new BooleanModelField("enableProgress", "开启任务运行进度显示", false);
+
     @Getter
     private static final BooleanModelField sendHookData = new BooleanModelField("sendHookData", "启用Hook数据转发", false);
 
@@ -188,6 +194,7 @@ public class BaseModel extends Model {
         modelFields.addField(recordLog);//是否记录日志
         modelFields.addField(showToast);//是否显示气泡提示
         modelFields.addField(enableOnGoing);//是否开启状态栏禁删
+        modelFields.addField(enableProgress);//是否开启任务运行进度显示
         modelFields.addField(languageSimplifiedChinese);//是否只显示中文并设置时区
         modelFields.addField(toastOffsetY);//气泡提示的纵向偏移量
         return modelFields;

--- a/app/src/main/java/fansirsqi/xposed/sesame/model/ModelOrder.java
+++ b/app/src/main/java/fansirsqi/xposed/sesame/model/ModelOrder.java
@@ -38,7 +38,7 @@ public class ModelOrder {
             AntStall.class,//蚂蚁新村
             GreenFinance.class,//绿色经营
 //            AntBookRead.class,//读书
-            ConsumeGold.class,//消费金
+//            ConsumeGold.class,//消费金
 //            OmegakoiTown.class,//小镇
             AnswerAI.class,//AI答题
     };

--- a/app/src/main/java/fansirsqi/xposed/sesame/task/ModelTask.java
+++ b/app/src/main/java/fansirsqi/xposed/sesame/task/ModelTask.java
@@ -287,6 +287,7 @@ public abstract class ModelTask extends Model {
      * @param force 是否强制启动
      */
     public static void startAllTask(Boolean force) {
+        Notify.setStatusTextExec();
         MAIN_TASK_FINISHED_LIST.clear();
         for (Model model : getModelArray()) {
             if (model != null) {

--- a/app/src/main/java/fansirsqi/xposed/sesame/task/ModelTask.java
+++ b/app/src/main/java/fansirsqi/xposed/sesame/task/ModelTask.java
@@ -291,7 +291,7 @@ public abstract class ModelTask extends Model {
         new Thread(() -> {
             try {
                 taskCompletionLatch.await(); // 等待所有任务完成
-                Notify.updateNextExecText(-1);
+                Notify.forceUpdateText();
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             }
@@ -465,6 +465,9 @@ public abstract class ModelTask extends Model {
      * 获取总任务执行进度 100%
      */
     public static int completedTaskPercentage() {
+        if (taskCompletionLatch == null) {
+            return 100;
+        }
         int totalTaskCount = getModelArray().length;
         return (int) ((totalTaskCount - taskCompletionLatch.getCount()) * 100 / totalTaskCount);
     }

--- a/app/src/main/java/fansirsqi/xposed/sesame/task/ModelTask.java
+++ b/app/src/main/java/fansirsqi/xposed/sesame/task/ModelTask.java
@@ -272,7 +272,6 @@ public abstract class ModelTask extends Model {
         childTaskMap.clear();
         MAIN_THREAD_POOL.remove(mainRunnable);
         MAIN_TASK_MAP.remove(this);
-        MAIN_TASK_FINISHED_LIST.add(this.hashCode());
     }
 
     /**

--- a/app/src/main/java/fansirsqi/xposed/sesame/task/ModelTask.java
+++ b/app/src/main/java/fansirsqi/xposed/sesame/task/ModelTask.java
@@ -454,6 +454,13 @@ public abstract class ModelTask extends Model {
         return MAIN_TASK_FINISHED_LIST.size() == getModelArray().length;
     }
 
+    /**
+     * 获取总任务执行进度 100%
+     */
+    public static int completedTaskPercentage() {
+        return MAIN_TASK_FINISHED_LIST.size() * 100 / getModelArray().length;
+    }
+
     public interface CancelTask {
 
         void cancel();

--- a/app/src/main/java/fansirsqi/xposed/sesame/task/antForest/AntForest.java
+++ b/app/src/main/java/fansirsqi/xposed/sesame/task/antForest/AntForest.java
@@ -343,7 +343,6 @@ public class AntForest extends ModelTask {
             totalCollected = StatisticsUtil.getData(StatisticsUtil.TimeType.DAY, StatisticsUtil.DataType.COLLECTED);
             totalHelpCollected = StatisticsUtil.getData(StatisticsUtil.TimeType.DAY, StatisticsUtil.DataType.HELPED);
             totalWatered = StatisticsUtil.getData(StatisticsUtil.TimeType.DAY, StatisticsUtil.DataType.WATERED);
-            Notify.setStatusTextExec();
             taskCount.set(0);
             selfId = UserMap.getCurrentUid();
             usePropBeforeCollectEnergy(selfId);

--- a/app/src/main/java/fansirsqi/xposed/sesame/task/antMember/AntMember.java
+++ b/app/src/main/java/fansirsqi/xposed/sesame/task/antMember/AntMember.java
@@ -3,9 +3,7 @@ package fansirsqi.xposed.sesame.task.antMember;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
-
 import java.util.Arrays;
-
 import fansirsqi.xposed.sesame.model.ModelFields;
 import fansirsqi.xposed.sesame.model.ModelGroup;
 import fansirsqi.xposed.sesame.model.modelFieldExt.BooleanModelField;
@@ -295,14 +293,18 @@ public class AntMember extends ModelTask {
       String taskTemplateId = task.getString("templateId");
       String taskTitle = task.getString("title");
       int needCompleteNum = task.getInt("needCompleteNum");
-      int completedNum = task.has("completedNum") ? task.getInt("completedNum") : 0;
+      int completedNum = task.optInt("completedNum", 0);
       String s;
       String recordId;
       JSONObject responseObj;
+      if (task.getString("actionUrl").contains("jumpAction")) {
+        // 跳转APP任务 依赖跳转的APP发送请求鉴别任务完成 仅靠hook支付宝无法完成
+        continue;
+      }
       if (!task.has("todayFinish")) {
         // 领取任务
         s = AntMemberRpcCall.joinSesameTask(taskTemplateId);
-        ThreadUtil.sleep(500);
+        ThreadUtil.sleep(200);
         responseObj = new JSONObject(s);
         if (!responseObj.optBoolean("success")) {
           Log.other(TAG, "芝麻信用💳[领取任务" + taskTitle + "失败]#" + s);
@@ -319,10 +321,10 @@ public class AntMember extends ModelTask {
         recordId = task.getString("recordId");
       }
       s = AntMemberRpcCall.feedBackSesameTask(taskTemplateId);
-      ThreadUtil.sleep(1000);
+      ThreadUtil.sleep(200);
       responseObj = new JSONObject(s);
       if (!responseObj.optBoolean("success")) {
-        Log.other(TAG, "芝麻信用💳[任务" + taskTitle + "回调失败]#" + s);
+        Log.other(TAG, "芝麻信用💳[任务" + taskTitle + "回调失败]#" + responseObj.getString("errorMessage"));
         Log.error(TAG + ".joinAndFinishSesameTask.feedBackSesameTask", "芝麻信用💳[任务" + taskTitle + "回调失败]#" + s);
         continue;
       }
@@ -333,9 +335,11 @@ public class AntMember extends ModelTask {
         case "xianyonghoufu_new": // 体验先用后付
           continue;
       }
-      if (task.has("jumpToPushModel") && task.getBoolean("jumpToPushModel")) {
+      // 是否为浏览15s任务
+      boolean assistiveTouch = task.getJSONObject("strategyRule").optBoolean("assistiveTouch");
+      if (task.optBoolean("jumpToPushModel") || assistiveTouch) {
         s = AntMemberRpcCall.finishSesameTask(recordId);
-        ThreadUtil.sleep(4000);
+        ThreadUtil.sleep(16000);
         responseObj = new JSONObject(s);
         if (!responseObj.optBoolean("success")) {
           Log.other(TAG, "芝麻信用💳[任务" + taskTitle + "完成失败]#" + s);

--- a/app/src/main/java/fansirsqi/xposed/sesame/task/antMember/AntMember.java
+++ b/app/src/main/java/fansirsqi/xposed/sesame/task/antMember/AntMember.java
@@ -239,7 +239,8 @@ public class AntMember extends ModelTask {
       String s = AntMemberRpcCall.queryHome();
       JSONObject jo = new JSONObject(s);
       if (!jo.optBoolean("success")) {
-        Log.other(TAG + ".checkSesameCanRun.queryHome", jo.optString("errorMsg"));
+        Log.other(TAG, "芝麻信用💳[首页响应失败]#" + jo.optString("errorMsg"));
+        Log.error(TAG + ".checkSesameCanRun.queryHome", "芝麻信用💳[首页响应失败]#" + s);
         return false;
       }
       JSONObject entrance = jo.getJSONObject("entrance");
@@ -266,7 +267,8 @@ public class AntMember extends ModelTask {
         jo = jo.getJSONObject("resData");
       }
       if (!jo.optBoolean("success")) {
-        Log.other(TAG + ".doAllAvailableSesameTask.queryAvailableSesameTask", jo.getString("resultCode"));
+        Log.other(TAG, "芝麻信用💳[查询任务响应失败]#" + jo.getString("resultCode"));
+        Log.error(TAG + ".doAllAvailableSesameTask.queryAvailableSesameTask", "芝麻信用💳[查询任务响应失败]#" + s);
         return;
       }
       JSONObject taskObj = jo.getJSONObject("data");
@@ -297,49 +299,51 @@ public class AntMember extends ModelTask {
       String s;
       String recordId;
       JSONObject responseObj;
-      if (task.getString("actionUrl").contains("jumpAction")) {
-        // 跳转APP任务 依赖跳转的APP发送请求鉴别任务完成 仅靠hook支付宝无法完成
-        continue;
-      }
       if (!task.has("todayFinish")) {
         // 领取任务
         s = AntMemberRpcCall.joinSesameTask(taskTemplateId);
         ThreadUtil.sleep(500);
         responseObj = new JSONObject(s);
         if (!responseObj.optBoolean("success")) {
-          Log.error("芝麻信用💳[领取任务" + taskTitle + "失败]#" + s);
+          Log.other(TAG, "芝麻信用💳[领取任务" + taskTitle + "失败]#" + s);
+          Log.error(TAG + ".joinAndFinishSesameTask.joinSesameTask", "芝麻信用💳[领取任务" + taskTitle + "失败]#" + s);
           continue;
         }
         recordId = responseObj.getJSONObject("data").getString("recordId");
       } else {
         if (!task.has("recordId")) {
-          Log.error("芝麻信用💳[任务" + taskTitle + "未获取到recordId]#" + task);
+          Log.other(TAG, "芝麻信用💳[任务" + taskTitle + "未获取到recordId]#" + task);
+          Log.error(TAG + ".joinAndFinishSesameTask", "芝麻信用💳[任务" + taskTitle + "未获取到recordId]#" + task);
           continue;
         }
         recordId = task.getString("recordId");
       }
       s = AntMemberRpcCall.feedBackSesameTask(taskTemplateId);
-      ThreadUtil.sleep(16000);
+      ThreadUtil.sleep(1000);
       responseObj = new JSONObject(s);
       if (!responseObj.optBoolean("success")) {
-        Log.error("芝麻信用💳[任务" + taskTitle + "回调失败]#" + s);
+        Log.other(TAG, "芝麻信用💳[任务" + taskTitle + "回调失败]#" + s);
+        Log.error(TAG + ".joinAndFinishSesameTask.feedBackSesameTask", "芝麻信用💳[任务" + taskTitle + "回调失败]#" + s);
         continue;
       }
-      // 无法自动完成的任务只领取，不操作完成，否则会报错
+      // 无法完成的任务
       switch (taskTemplateId) {
         case "save_ins_universal_new": // 坚持攒保证金
         case "xiaofeijin_visit_new": // 坚持攒消费金金币
         case "xianyonghoufu_new": // 体验先用后付
           continue;
       }
-      s = AntMemberRpcCall.finishSesameTask(recordId);
-      ThreadUtil.sleep(4000);
-      responseObj = new JSONObject(s);
-      if (!responseObj.optBoolean("success")) {
-        Log.error("芝麻信用💳[任务" + taskTitle + "完成失败]#" + s);
-        continue;
+      if (task.has("jumpToPushModel") && task.getBoolean("jumpToPushModel")) {
+        s = AntMemberRpcCall.finishSesameTask(recordId);
+        ThreadUtil.sleep(4000);
+        responseObj = new JSONObject(s);
+        if (!responseObj.optBoolean("success")) {
+          Log.other(TAG, "芝麻信用💳[任务" + taskTitle + "完成失败]#" + s);
+          Log.error(TAG + ".joinAndFinishSesameTask.finishSesameTask", "芝麻信用💳[任务" + taskTitle + "完成失败]#" + s);
+          continue;
+        }
       }
-      Log.other("芝麻信用💳[" + taskTitle + "]#(" + (completedNum + 1) + "/" + needCompleteNum + "天)");
+      Log.other("芝麻信用💳[完成任务" + taskTitle + "]#(" + (completedNum + 1) + "/" + needCompleteNum + "天)");
     }
   }
 
@@ -352,7 +356,8 @@ public class AntMember extends ModelTask {
       JSONObject jo = new JSONObject(AntMemberRpcCall.queryCreditFeedback());
       ThreadUtil.sleep(500);
       if (!jo.optBoolean("success")) {
-        Log.other(TAG + ".collectSesame.queryCreditFeedback", jo.getString("resultView"));
+        Log.other(TAG, "芝麻信用💳[查询未领取芝麻粒响应失败]#" + jo.getString("resultView"));
+        Log.error(TAG + ".collectSesame.queryCreditFeedback", "芝麻信用💳[查询未领取芝麻粒响应失败]#" + jo);
         return;
       }
       JSONArray availableCollectList = jo.getJSONArray("creditFeedbackVOS");
@@ -361,7 +366,8 @@ public class AntMember extends ModelTask {
         jo = new JSONObject(AntMemberRpcCall.collectAllCreditFeedback());
         ThreadUtil.sleep(2000);
         if (!jo.optBoolean("success")) {
-          Log.other(TAG + ".collectSesame.collectAllCreditFeedback", jo.optString("resultView"));
+          Log.other(TAG, "芝麻信用💳[一键收取芝麻粒响应失败]#" + jo);
+          Log.error(TAG + ".collectSesame.collectAllCreditFeedback", "芝麻信用💳[一键收取芝麻粒响应失败]#" + jo);
           return;
         }
       }
@@ -377,7 +383,8 @@ public class AntMember extends ModelTask {
           jo = new JSONObject(AntMemberRpcCall.collectCreditFeedback(creditFeedbackId));
           ThreadUtil.sleep(2000);
           if (!jo.optBoolean("success")) {
-            Log.other(TAG + ".collectSesame.collectCreditFeedback", jo.optString("resultView"));
+            Log.other(TAG, "芝麻信用💳[查询未领取芝麻粒响应失败]#" + jo.getString("resultView"));
+            Log.error(TAG + ".collectSesame.collectCreditFeedback", "芝麻信用💳[收取芝麻粒响应失败]#" + jo);
             continue;
           }
         }

--- a/app/src/main/java/fansirsqi/xposed/sesame/task/antMember/AntMember.java
+++ b/app/src/main/java/fansirsqi/xposed/sesame/task/antMember/AntMember.java
@@ -292,7 +292,7 @@ public class AntMember extends ModelTask {
       String taskTemplateId = task.getString("templateId");
       String taskTitle = task.getString("title");
       int needCompleteNum = task.getInt("needCompleteNum");
-      int completedNum = task.getInt("completedNum");
+      int completedNum = task.has("completedNum") ? task.getInt("completedNum") : 0;
       String s;
       String recordId;
       JSONObject responseObj;

--- a/app/src/main/java/fansirsqi/xposed/sesame/task/antMember/AntMember.java
+++ b/app/src/main/java/fansirsqi/xposed/sesame/task/antMember/AntMember.java
@@ -163,6 +163,7 @@ public class AntMember extends ModelTask {
 
   /**
    * 会员任务-逛一逛
+   * 单次执行 1
    */
   private void doAllMemberAvailableTask() {
     try {
@@ -170,18 +171,19 @@ public class AntMember extends ModelTask {
       ThreadUtil.sleep(500);
       JSONObject jsonObject = new JSONObject(str);
       if (!ResUtil.checkResCode(jsonObject)) {
-        Log.runtime(TAG, "doAllMemberAvailableTask err:" + jsonObject.getString("resultDesc"));
+        Log.error(TAG + ".doAllMemberAvailableTask", "会员任务响应失败: " + jsonObject.getString("resultDesc"));
         return;
       }
       if (!jsonObject.has("availableTaskList")) {
         return;
       }
       JSONArray taskList = jsonObject.getJSONArray("availableTaskList");
-      for (int j = 0; j < taskList.length(); j++) {
-        ThreadUtil.sleep(16000);
-        JSONObject task = taskList.getJSONObject(j);
-        processTask(task);
+      if (taskList.length() == 0) {
+        return;
       }
+      JSONObject task = taskList.getJSONObject(0);
+      ThreadUtil.sleep(16000);
+      processTask(task);
     } catch (Throwable t) {
       Log.runtime(TAG, "doAllMemberAvailableTask err:");
       Log.printStackTrace(TAG, t);
@@ -209,7 +211,7 @@ public class AntMember extends ModelTask {
           s = AntMemberRpcCall.receivePointByUser(id);
           jo = new JSONObject(s);
           if (ResUtil.checkResCode(jo)) {
-            Log.other("会员积分🎖️[" + bizTitle + "]#" + pointAmount + "积分");
+            Log.other("会员积分🎖️[领取" + bizTitle + "]#" + pointAmount + "积分");
           } else {
             Log.record(jo.getString("resultDesc"));
             Log.runtime(s);
@@ -649,7 +651,6 @@ public class AntMember extends ModelTask {
   /**
    * 执行会员任务 类型1
    * @param task 单个任务对象
-   * @return 如果任务处理成功，则返回true；否则返回false
    */
   private void processTask(JSONObject task) throws JSONException {
     JSONObject taskConfigInfo = task.getJSONObject("taskConfigInfo");
@@ -670,6 +671,7 @@ public class AntMember extends ModelTask {
     JSONObject jo = new JSONObject(str);
     if (!ResUtil.checkResCode(jo)) {
       Log.runtime(TAG, "执行任务失败:" + jo.optString("resultDesc"));
+      return;
     }
     Log.other("会员任务🎖️[" + name + "]#获得积分" + awardParamPoint);
   }

--- a/app/src/main/java/fansirsqi/xposed/sesame/task/antMember/AntMember.java
+++ b/app/src/main/java/fansirsqi/xposed/sesame/task/antMember/AntMember.java
@@ -271,6 +271,7 @@ public class AntMember extends ModelTask {
       }
       JSONObject taskObj = jo.getJSONObject("data");
       if (taskObj.has("dailyTaskListVO")) {
+        joinAndFinishSesameTask(taskObj.getJSONObject("dailyTaskListVO").getJSONArray("waitCompleteTaskVOS"));
         joinAndFinishSesameTask(taskObj.getJSONObject("dailyTaskListVO").getJSONArray("waitJoinTaskVOS"));
       }
       if (taskObj.has("toCompleteVOS")) {

--- a/app/src/main/java/fansirsqi/xposed/sesame/util/Log.java
+++ b/app/src/main/java/fansirsqi/xposed/sesame/util/Log.java
@@ -109,6 +109,9 @@ public class Log {
 
 
     public static void error(String message) {
+        if (BaseModel.getErrNotify().getValue()) {
+            Notify.sendErrorNotification("‼️芝麻粒运行时发生异常，详情查看异常日志", message);
+        }
         runtime(message);
         ERROR_LOGGER.error(TAG + "{}", message);
     }

--- a/app/src/main/java/fansirsqi/xposed/sesame/util/Notify.java
+++ b/app/src/main/java/fansirsqi/xposed/sesame/util/Notify.java
@@ -23,9 +23,6 @@ public class Notify {
     private static final String CHANNEL_ID = "fansirsqi.xposed.sesame.ANTFOREST_NOTIFY_CHANNEL";
     private static NotificationManager mNotifyManager;
     private static Notification.Builder builder;
-
-    @Getter
-    private static volatile long lastNoticeTime = 0;
     private static long nextExecTimeCache = 0;
     private static String titleText = "";
     private static String contentText = "";
@@ -114,7 +111,6 @@ public class Notify {
             }
 
             titleText = status;
-            lastNoticeTime = System.currentTimeMillis();
             mainHandler.post(Notify::sendText);
         } catch (Exception e) {
             Log.printStackTrace(e);
@@ -157,7 +153,6 @@ public class Notify {
     public static void updateLastExecText(String content) {
         try {
             contentText = "📌 上次执行 " + TimeUtil.getTimeStr(System.currentTimeMillis()) + "\n🌾 " + content;
-            lastNoticeTime = System.currentTimeMillis();
             mainHandler.post(Notify::sendText);
         } catch (Exception e) {
             Log.printStackTrace(e);

--- a/app/src/main/java/fansirsqi/xposed/sesame/util/Notify.java
+++ b/app/src/main/java/fansirsqi/xposed/sesame/util/Notify.java
@@ -148,7 +148,11 @@ public class Notify {
             if (forestPauseTime > System.currentTimeMillis()) {
                 status = "❌ 触发异常，等待至" + TimeUtil.getCommonDate(forestPauseTime) + "恢复运行";
             }
-
+            if (BaseModel.getEnableProgress().getValue() && !ModelTask.isAllTaskFinished()) {
+                builder.setProgress(100, ModelTask.completedTaskPercentage(), false);
+            } else {
+                builder.setProgress(0, 0, false);
+            }
             titleText = status;
             mainHandler.post(Notify::sendText);
         } catch (Exception e) {
@@ -166,7 +170,14 @@ public class Notify {
             if (nextExecTime != -1) {
                 nextExecTimeCache = nextExecTime;
             }
-            titleText = nextExecTimeCache > 0 ? "⏰ 下次执行 " + TimeUtil.getTimeStr(nextExecTimeCache) : "";
+            if (BaseModel.getEnableProgress().getValue() && !ModelTask.isAllTaskFinished()) {
+                builder.setProgress(100, ModelTask.completedTaskPercentage(), false);
+            } else {
+                builder.setProgress(0, 0, false);
+            }
+            if (ModelTask.isAllTaskFinished()) {
+                titleText = nextExecTimeCache > 0 ? "⏰ 下次执行 " + TimeUtil.getTimeStr(nextExecTimeCache) : "";
+            }
             mainHandler.post(Notify::sendText);
         } catch (Exception e) {
             Log.printStackTrace(e);
@@ -219,9 +230,7 @@ public class Notify {
             if (!StringUtil.isEmpty(contentText)) {
                 builder.setContentText(contentText);
             }
-            if (BaseModel.getEnableProgress().getValue() && !ModelTask.isAllTaskFinished()) {
-                builder.setProgress(100, ModelTask.completedTaskPercentage(), false);
-            } else {
+            if (!BaseModel.getEnableProgress().getValue()) {
                 builder.setProgress(0, 0, false);
             }
             mNotifyManager.notify(NOTIFICATION_ID, builder.build());

--- a/app/src/main/java/fansirsqi/xposed/sesame/util/Notify.java
+++ b/app/src/main/java/fansirsqi/xposed/sesame/util/Notify.java
@@ -12,7 +12,6 @@ import android.os.Looper;
 import fansirsqi.xposed.sesame.data.RuntimeInfo;
 import fansirsqi.xposed.sesame.model.BaseModel;
 import fansirsqi.xposed.sesame.task.ModelTask;
-import lombok.Getter;
 
 public class Notify {
     private static final Handler mainHandler = new Handler(Looper.getMainLooper()); // 主线程 Handler
@@ -153,6 +152,22 @@ public class Notify {
      */
     public static void setStatusTextExec() {
         updateStatusText("⚙️ 芝麻粒正在施工中...");
+    }
+
+    /**
+     * 设置状态文本为已禁用
+     */
+    public static void setStatusTextDisabled() {
+        try {
+            builder.setContentTitle("🚫 芝麻粒已禁用");
+            if (!StringUtil.isEmpty(contentText)) {
+                builder.setContentText(contentText);
+            }
+            builder.setProgress(0, 0, false);
+            mNotifyManager.notify(NOTIFICATION_ID, builder.build());
+        } catch (Exception e) {
+            Log.printStackTrace(e);
+        }
     }
 
     /**

--- a/app/src/main/java/fansirsqi/xposed/sesame/util/Notify.java
+++ b/app/src/main/java/fansirsqi/xposed/sesame/util/Notify.java
@@ -124,22 +124,11 @@ public class Notify {
      */
     public static void updateNextExecText(long nextExecTime) {
         try {
-            boolean refresh = false;
             if (nextExecTime != -1) {
                 nextExecTimeCache = nextExecTime;
             }
-            if (BaseModel.getEnableProgress().getValue()) {
-                builder.setProgress(100, ModelTask.completedTaskPercentage(), false);
-                refresh = true;
-            }
-            if (ModelTask.isAllTaskFinished()) {
-                titleText = nextExecTimeCache > 0 ? "⏰ 下次执行 " + TimeUtil.getTimeStr(nextExecTimeCache) : "";
-                builder.setProgress(0, 0, false);
-                refresh = true;
-            }
-            if (refresh) {
-                mainHandler.post(Notify::sendText);
-            }
+            titleText = nextExecTimeCache > 0 ? "⏰ 下次执行 " + TimeUtil.getTimeStr(nextExecTimeCache) : "";
+            mainHandler.post(Notify::sendText);
         } catch (Exception e) {
             Log.printStackTrace(e);
         }
@@ -163,10 +152,6 @@ public class Notify {
      * 设置状态文本为执行中。
      */
     public static void setStatusTextExec() {
-        Log.debug("进度更新[施工中]: " + ModelTask.completedTaskPercentage());
-        if (BaseModel.getEnableProgress().getValue()) {
-            builder.setProgress(100, 0, false);
-        }
         updateStatusText("⚙️ 芝麻粒正在施工中...");
     }
 
@@ -178,6 +163,11 @@ public class Notify {
             builder.setContentTitle(titleText);
             if (!StringUtil.isEmpty(contentText)) {
                 builder.setContentText(contentText);
+            }
+            if (BaseModel.getEnableProgress().getValue() && !ModelTask.isAllTaskFinished()) {
+                builder.setProgress(100, ModelTask.completedTaskPercentage(), false);
+            } else {
+                builder.setProgress(0, 0, false);
             }
             mNotifyManager.notify(NOTIFICATION_ID, builder.build());
         } catch (Exception e) {

--- a/app/src/main/java/fansirsqi/xposed/sesame/util/Notify.java
+++ b/app/src/main/java/fansirsqi/xposed/sesame/util/Notify.java
@@ -19,12 +19,52 @@ public class Notify {
     @SuppressLint("StaticFieldLeak")
     public static Context context;
     private static final int NOTIFICATION_ID = 99;
+    private static final int ERROR_NOTIFICATION_ID = 98;
     private static final String CHANNEL_ID = "fansirsqi.xposed.sesame.ANTFOREST_NOTIFY_CHANNEL";
     private static NotificationManager mNotifyManager;
     private static Notification.Builder builder;
     private static long nextExecTimeCache = 0;
     private static String titleText = "";
     private static String contentText = "";
+
+    @SuppressLint("ObsoleteSdkInt")
+    public static void sendErrorNotification(String title, String content) {
+        try {
+            if (context == null) {
+                return;
+            }
+            mNotifyManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                NotificationChannel notificationChannel = new NotificationChannel(CHANNEL_ID, "‼️ 芝麻粒异常通知", NotificationManager.IMPORTANCE_LOW);
+                mNotifyManager.createNotificationChannel(notificationChannel);
+                builder = new Notification.Builder(context, CHANNEL_ID);
+            } else {
+                //安卓8.0以下
+                builder = new Notification.Builder(context).setPriority(Notification.PRIORITY_LOW);
+            }
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P)
+                builder.setCategory(Notification.CATEGORY_ERROR);
+            builder
+                    .setSmallIcon(android.R.drawable.sym_def_app_icon)
+                    .setLargeIcon(BitmapFactory.decodeResource(context.getResources(), android.R.drawable.sym_def_app_icon))
+                    .setContentTitle(title)
+                    .setContentText(content)
+                    .setSubText("芝麻粒")
+                    .setAutoCancel(true);
+            Notification mNotification = builder.build();
+            if (context instanceof Service) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                    mNotifyManager.notify(NOTIFICATION_ID, mNotification);
+                } else {
+                    ((Service) context).startForeground(NOTIFICATION_ID, mNotification);
+                }
+            } else {
+                mNotifyManager.notify(NOTIFICATION_ID, mNotification);
+            }
+        } catch (Exception e) {
+            Log.printStackTrace(e);
+        }
+    }
 
     public static void start(Context context) {
         try {

--- a/app/src/main/java/fansirsqi/xposed/sesame/util/Notify.java
+++ b/app/src/main/java/fansirsqi/xposed/sesame/util/Notify.java
@@ -92,6 +92,8 @@ public class Notify {
             builder
                     .setSmallIcon(android.R.drawable.sym_def_app_icon)
                     .setLargeIcon(BitmapFactory.decodeResource(context.getResources(), android.R.drawable.sym_def_app_icon))
+                    .setContentTitle(titleText)
+                    .setContentText(contentText)
                     .setSubText("芝麻粒")
                     .setAutoCancel(false)
                     .setContentIntent(pi);

--- a/app/src/main/java/fansirsqi/xposed/sesame/util/Notify.java
+++ b/app/src/main/java/fansirsqi/xposed/sesame/util/Notify.java
@@ -54,12 +54,12 @@ public class Notify {
             Notification mNotification = builder.build();
             if (context instanceof Service) {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-                    mNotifyManager.notify(NOTIFICATION_ID, mNotification);
+                    mNotifyManager.notify(ERROR_NOTIFICATION_ID, mNotification);
                 } else {
-                    ((Service) context).startForeground(NOTIFICATION_ID, mNotification);
+                    ((Service) context).startForeground(ERROR_NOTIFICATION_ID, mNotification);
                 }
             } else {
-                mNotifyManager.notify(NOTIFICATION_ID, mNotification);
+                mNotifyManager.notify(ERROR_NOTIFICATION_ID, mNotification);
             }
         } catch (Exception e) {
             Log.printStackTrace(e);


### PR DESCRIPTION
- 通知添加任务执行进度条展示（可配置）

- 芝麻粒禁用状态展示在通知栏

- 加入运行异常发送通知的逻辑

	> 不知道为什么有这个配置但是没有这块逻辑，我记得之前还有通知来着

- 干掉消费金

	> 现在用起来会被短期封号(C !)，等解封后再研究

- 芝麻信用相关任务逻辑优化

- 会员任务完成状况二次校验