### PR TITLE
refactor: 优化 RPC 响应错误日志的格式

### DIFF
--- a/app/src/main/java/fansirsqi/xposed/sesame/hook/rpc/bridge/NewRpcBridge.java
+++ b/app/src/main/java/fansirsqi/xposed/sesame/hook/rpc/bridge/NewRpcBridge.java
@@ -125,7 +125,7 @@ public class NewRpcBridge implements RpcBridge {
                                         if (!(Boolean) XposedHelpers.callMethod(obj, "containsKey", "success")
                                                 && !(Boolean) XposedHelpers.callMethod(obj, "containsKey", "isSuccess")) {
                                             rpcEntity.setError();
-                                            Log.error("new rpc response | id: " + rpcEntity.hashCode() + " | method: " + rpcEntity.getRequestMethod() + " args: " + rpcEntity.getRequestData() + " | data: " + rpcEntity.getResponseString());
+                                            Log.error("new rpc response | id: " + rpcEntity.hashCode() + " | method: " + rpcEntity.getRequestMethod() + "\n args: " + rpcEntity.getRequestData() + " |\n data: " + rpcEntity.getResponseString());
                                         }
                                     } catch (Exception e) {
                                         rpcEntity.setError();


### PR DESCRIPTION
- 在 NewRpcBridge 类中，修改了 RPC 响应错误日志的输出格式
- 通过换行符优化了日志的可读性，使方法、参数和数据部分更加清晰
- 测试PR-CI