### PR TITLE
增加森林抽抽乐抽奖、修改再次检测逻辑

### DIFF
--- a/app/src/main/java/fansirsqi/xposed/sesame/task/antForest/AntForestRpcCall.java
+++ b/app/src/main/java/fansirsqi/xposed/sesame/task/antForest/AntForestRpcCall.java
@@ -704,6 +704,9 @@ public class AntForestRpcCall {
         return RequestManager.requestString("com.alipay.antiepdrawprod.exchangeTimesFromTaskopengreen", args);
     }
 
+    /**
+     * 森林抽抽乐-任务-广告
+     */
     public static String finishTask4Chouchoule(String taskType, String sceneCode) throws JSONException {
         //[{"outBizNo":"FOREST_NORMAL_DRAW_XLIGHT_1_1749288736354_ffba6daf","requestType":"RPC","sceneCode":"ANTFOREST_NORMAL_DRAW_TASK","source":"ADBASICLIB","taskType":"FOREST_NORMAL_DRAW_XLIGHT_1"}]
         JSONObject params = new JSONObject();
@@ -714,6 +717,21 @@ public class AntForestRpcCall {
         params.put("taskType", taskType);
         String args = "[" + params + "]";
         return RequestManager.requestString("com.alipay.antiep.finishTask", args);
+    }
+
+    /**
+     * 森林抽抽乐-抽奖
+     */
+    public static String drawopengreen(String activityId, String sceneCode, String source, String userId) throws JSONException {
+        JSONObject params = new JSONObject();
+        params.put("activityId", activityId);
+        params.put("requestType", "RPC");
+        params.put("sceneCode", sceneCode);
+        params.put("source", source);
+        params.put("userId", userId);
+        String args = "[" + params + "]";
+        return RequestManager.requestString("com.alipay.antiepdrawprod.drawopengreen", args,
+                "antiepdrawprod","draw","DrawRpc");
     }
 
 }

--- a/app/src/main/java/fansirsqi/xposed/sesame/task/antForest/ForestChouChouLe.java
+++ b/app/src/main/java/fansirsqi/xposed/sesame/task/antForest/ForestChouChouLe.java
@@ -59,29 +59,31 @@ public class ForestChouChouLe {
 
                             //注意这里的 taskSceneCode=listSceneCode = ANTFOREST_NORMAL_DRAW_TASK， sceneCode = ANTFOREST_NORMAL_DRAW
 
-                            if (taskStatus.equals(TaskStatus.TODO.name())) {//适配签到任务
+                            if (taskStatus.equals(TaskStatus.TODO.name())) { //适配签到任务
                                 if (taskType.equals("NORMAL_DRAW_EXCHANGE_VITALITY")) {//活力值兑换次数
                                     String sginRes = AntForestRpcCall.exchangeTimesFromTaskopengreen(activityId, sceneCode, source, taskSceneCode, taskType);
                                     if (ResUtil.checkSuccess(sginRes)) {
-                                        Log.forest(TAG, "📔完成森林抽抽乐任务：" + taskName);
+                                        Log.forest(TAG, "📔执行森林抽抽乐任务：" + taskName);
                                         taskFailMap.remove(taskName);
                                     }
                                 }
                                 if (taskType.equals("FOREST_NORMAL_DRAW_XLIGHT_1")) {
                                     String sginRes = AntForestRpcCall.finishTask4Chouchoule(taskType, taskSceneCode);
                                     if (ResUtil.checkSuccess(sginRes)) {
-                                        Log.forest(TAG, "📔完成森林抽抽乐任务：" + taskName);
+                                        Log.forest(TAG, "📔执行森林抽抽乐任务：" + taskName);
                                         taskFailMap.remove(taskName);
                                     }
                                 }
-                            } else if (taskStatus.equals(TaskStatus.FINISHED.name())) {//适配领奖任务
-                                if (taskType.equals("FOREST_NORMAL_DRAW_DAILY_SIGN")) {//适配签到任务
-                                    String sginRes = AntForestRpcCall.receiveTaskAwardopengreen(source, taskSceneCode, taskType);
-                                    if (ResUtil.checkSuccess(sginRes)) {
-                                        Log.forest(TAG, "📔完成森林抽抽乐任务：" + taskName);
-                                        taskFailMap.remove(taskName);
-                                    }
+                            }
+
+                            if (taskStatus.equals(TaskStatus.FINISHED.name())) {// 领取奖励
+//                                if (taskType.equals("FOREST_NORMAL_DRAW_DAILY_SIGN")) {//
+                                String sginRes = AntForestRpcCall.receiveTaskAwardopengreen(source, taskSceneCode, taskType);
+                                if (ResUtil.checkSuccess(sginRes)) {
+                                    Log.forest(TAG, "📔完成森林抽抽乐任务：" + taskName);
+                                    taskFailMap.remove(taskName);
                                 }
+//                                }
                             }
                             Integer failCountObj = taskFailMap.get(taskName);
                             int failCount = (failCountObj == null) ? 0 : failCountObj;
@@ -101,5 +103,6 @@ public class ForestChouChouLe {
         }
 
     }
+
 
 }

--- a/app/src/main/java/fansirsqi/xposed/sesame/task/antForest/ForestChouChouLe.java
+++ b/app/src/main/java/fansirsqi/xposed/sesame/task/antForest/ForestChouChouLe.java
@@ -15,9 +15,6 @@ public class ForestChouChouLe {
 
     private static final String TAG = ForestChouChouLe.class.getSimpleName();
 
-    private static final Map<String, Integer> taskFailMap = new HashMap<>();
-
-
     void chouChouLe() {
         try {
             boolean doublecheck;
@@ -32,7 +29,6 @@ public class ForestChouChouLe {
 
             long startTime = drawActivity.getLong("startTime");
             long endTime = drawActivity.getLong("endTime");
-            taskFailMap.clear();
             do {
                 doublecheck = false;
                 if (System.currentTimeMillis() > startTime && System.currentTimeMillis() < endTime) {// 时间范围内
@@ -47,7 +43,7 @@ public class ForestChouChouLe {
                             JSONObject bizInfo = new JSONObject(taskBaseInfo.getString("bizInfo"));
                             String taskName = bizInfo.getString("title");
                             String taskSceneCode = taskBaseInfo.getString("sceneCode");// == listSceneCode ==ANTFOREST_NORMAL_DRAW_TASK
-                            String taskStatus = taskBaseInfo.getString("taskStatus");
+                            String taskStatus = taskBaseInfo.getString("taskStatus"); // 任务状态: TODO => FINISHED => RECEIVED
                             String taskType = taskBaseInfo.getString("taskType");
 
                             JSONObject taskRights = taskInfo.getJSONObject("taskRights");
@@ -63,37 +59,32 @@ public class ForestChouChouLe {
                                 if (taskType.equals("NORMAL_DRAW_EXCHANGE_VITALITY")) {//活力值兑换次数
                                     String sginRes = AntForestRpcCall.exchangeTimesFromTaskopengreen(activityId, sceneCode, source, taskSceneCode, taskType);
                                     if (ResUtil.checkSuccess(sginRes)) {
-                                        Log.forest(TAG, "📔执行森林抽抽乐任务：" + taskName);
-                                        taskFailMap.remove(taskName);
+                                        Log.forest(TAG, "执行森林抽抽乐任务：" + taskName);
+                                        doublecheck = true;
                                     }
-                                }
-                                if (taskType.equals("FOREST_NORMAL_DRAW_XLIGHT_1")) {
+                                } else if (taskType.equals("FOREST_NORMAL_DRAW_XLIGHT_1")) {
                                     String sginRes = AntForestRpcCall.finishTask4Chouchoule(taskType, taskSceneCode);
                                     if (ResUtil.checkSuccess(sginRes)) {
-                                        Log.forest(TAG, "📔执行森林抽抽乐任务：" + taskName);
-                                        taskFailMap.remove(taskName);
+                                        Log.forest(TAG, "执行森林抽抽乐任务：" + taskName);
+                                        doublecheck = true;
                                     }
                                 }
                             }
 
                             if (taskStatus.equals(TaskStatus.FINISHED.name())) {// 领取奖励
-//                                if (taskType.equals("FOREST_NORMAL_DRAW_DAILY_SIGN")) {//
                                 String sginRes = AntForestRpcCall.receiveTaskAwardopengreen(source, taskSceneCode, taskType);
                                 if (ResUtil.checkSuccess(sginRes)) {
                                     Log.forest(TAG, "📔完成森林抽抽乐任务：" + taskName);
-                                    taskFailMap.remove(taskName);
+                                    // 检查是否需要再次检测任务
+                                    if (rightsTimesLimit - rightsTimes > 0) {
+                                        doublecheck = true;
+                                    }
                                 }
-//                                }
                             }
-                            Integer failCountObj = taskFailMap.get(taskName);
-                            int failCount = (failCountObj == null) ? 0 : failCountObj;
-                            if (rightsTimesLimit - rightsTimes > 0 && failCount < 3) {
-                                doublecheck = true;
-                            }
+
                         }
 
                     }
-
                 }
 
             } while (doublecheck);

--- a/app/src/main/java/fansirsqi/xposed/sesame/task/antForest/ForestChouChouLe.java
+++ b/app/src/main/java/fansirsqi/xposed/sesame/task/antForest/ForestChouChouLe.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import fansirsqi.xposed.sesame.task.TaskStatus;
 import fansirsqi.xposed.sesame.util.GlobalThreadPools;
 import fansirsqi.xposed.sesame.util.Log;
+import fansirsqi.xposed.sesame.util.Maps.UserMap;
 import fansirsqi.xposed.sesame.util.ResUtil;
 
 public class ForestChouChouLe {
@@ -89,6 +90,28 @@ public class ForestChouChouLe {
 
             } while (doublecheck);
 
+            // 执行抽奖
+            jo = new JSONObject(AntForestRpcCall.enterDrawActivityopengreen(source));
+            if (ResUtil.checkSuccess(jo)) {
+                drawScene = jo.optJSONObject("drawScene");
+                drawActivity = drawScene.optJSONObject("drawActivity");
+                activityId = drawActivity.optString("activityId");
+                sceneCode = drawActivity.optString("sceneCode");
+
+                JSONObject drawAsset = jo.optJSONObject("drawAsset");
+                int blance = drawAsset.optInt("blance", 0);
+                while (blance > 0) {
+                    jo = new JSONObject(AntForestRpcCall.drawopengreen(activityId,sceneCode,source, UserMap.getCurrentUid()));
+                    if (ResUtil.checkSuccess(jo)) {
+                        drawAsset = jo.optJSONObject("drawAsset");
+                        blance = drawAsset.optInt("blance", 0);
+                        JSONObject prizeVO = jo.optJSONObject("prizeVO");
+                        String prizeName = prizeVO.optString("prizeName");
+                        Integer prizeNum = prizeVO.optInt("prizeNum");
+                        Log.forest("森林寻宝任务🎁[领取: " + prizeName + "*" + prizeNum + "]");
+                    }
+                }
+            }
         } catch (Exception e) {
             Log.printStackTrace(e);
         }


### PR DESCRIPTION
任务状态分为：TODO => FINISHED => RECEIVED，任务执行完成后，必定需要领取“抽奖次数”，所以任务执行完成后doublecheck赋值为true。按照操作逻辑，可以执行多次的任务需要在领取了“抽奖次数”后，再进行下一次任务，所以在FINISHED 中进行次数判断。