### PR TITLE
增加不完整、不好用的子功能：森林抽抽乐-助力(确认邀请)

### DIFF
--- a/app/src/main/java/fansirsqi/xposed/sesame/task/antForest/AntForest.java
+++ b/app/src/main/java/fansirsqi/xposed/sesame/task/antForest/AntForest.java
@@ -176,6 +176,7 @@ public class AntForest extends ModelTask {
     private ListModelField.ListJoinCommaToStringModelField bubbleBoostTime;
 
     private BooleanModelField forestChouChouLe;//森林抽抽乐
+    private ListModelField.ListJoinCommaToStringModelField forestChouChouLeShareIds; // 森林抽抽乐邀请id列表
     private static boolean canConsumeAnimalProp;
     private static int totalCollected = 0;
     private static int totalHelpCollected = 0;
@@ -297,7 +298,9 @@ public class AntForest extends ModelTask {
         modelFields.addField(ecoLifeOption = new SelectModelField("ecoLifeOption", "绿色行动 | 选项", new LinkedHashSet<>(), OtherEntity::listEcoLifeOptions,
                 "光盘行动需要先完成一次光盘打卡"));
 
-        modelFields.addField(forestChouChouLe = new BooleanModelField("forestChouChouLe", "森林寻宝任务-未完成", false));
+        modelFields.addField(forestChouChouLe = new BooleanModelField("forestChouChouLe", "森林寻宝任务", false));
+        modelFields.addField(forestChouChouLeShareIds = new ListModelField.ListJoinCommaToStringModelField("forestChouChouLeShareIds", "森林寻宝任务|分享ID列表-不好用", ListUtil.newArrayList(
+                "")));
 
         modelFields.addField(queryInterval = new StringModelField("queryInterval", "查询间隔(毫秒或毫秒范围)", "1000-2000"));
         modelFields.addField(collectInterval = new StringModelField("collectInterval", "收取间隔(毫秒或毫秒范围)", "1000-1500"));
@@ -460,8 +463,11 @@ public class AntForest extends ModelTask {
                 if (dailyCheckIn.getValue()) {
                     Privilege.studentSignInRedEnvelope();
                 }
+
+                // 森林抽抽乐
                 if (forestChouChouLe.getValue()) {
                     ForestChouChouLe chouChouLe = new ForestChouChouLe();
+                    chouChouLe.confirmShareRecall(forestChouChouLeShareIds.getValue()); // 执行助力(确认分享)操作
                     chouChouLe.chouChouLe();
                 }
             }

--- a/app/src/main/java/fansirsqi/xposed/sesame/task/antForest/AntForestRpcCall.java
+++ b/app/src/main/java/fansirsqi/xposed/sesame/task/antForest/AntForestRpcCall.java
@@ -734,6 +734,40 @@ public class AntForestRpcCall {
                 "antiepdrawprod","draw","DrawRpc");
     }
 
+    /**
+     * 获取邀请链接对应的用户ID
+     */
+    public static String shareComponentRecall(String shareId) throws JSONException{
+        JSONObject params = new JSONObject();
+        params.put("iepShareChannelType", "qrcode");
+        params.put("requestType", "RPC");
+        params.put("sceneCode", "FOREST_NORMAL_20250510_SHARE");
+        params.put("shareId", shareId);
+        params.put("source", "chouchoule");
+        String args = "[" + params + "]";
+        return RequestManager.requestString("com.alipay.antiep.shareComponentRecall", args);
+
+    }
+
+    /**
+     *
+     * 确认邀请
+     */
+    public static String confirmShareRecall(String userId, String shareId ) throws JSONException {
+        JSONObject params = new JSONObject();
+        JSONObject beSharedBizExtInfo = new JSONObject();
+        beSharedBizExtInfo.put("drawActivityId", "2025060301");
+        beSharedBizExtInfo.put("inviterUid", userId);
+        params.put("beSharedBizExtInfo", beSharedBizExtInfo);
+        params.put("requestType", "RPC");
+        params.put("sceneCode", "FOREST_NORMAL_20250510_SHARE");
+        params.put("shareId", shareId);
+        params.put("source", "chouchoule");
+        params.put("userId", userId);
+        String args = "[" + params + "]";
+        return RequestManager.requestString("com.alipay.antiep.confirmShareRecall", args);
+    }
+
 }
 
 


### PR DESCRIPTION
RT
1. 功能不完善，未找到能检查“当天是否有确认该邀请”的接口（或许后续可以将`UserId`或`shareId`存入`Status.json`中）
2. 因为`shareId`太长，不太好输入也不太好查看（计划：修改List的显示方式，应该后续。。。咕咕咕？）
3. `shareId`获取较麻烦，一个是抓包，一个是通过解析邀请二维码，然后再解析邀请短链后(也可以直接获取短链），进行提取
