### PR TITLE
修复一加系更新8月安全补丁后导致的hook失败

### DIFF
--- a/app/src/main/java/fansirsqi/xposed/sesame/hook/ApplicationHook.java
+++ b/app/src/main/java/fansirsqi/xposed/sesame/hook/ApplicationHook.java
@@ -31,9 +31,13 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.lang.reflect.Method;
+import java.lang.reflect.Member;
+import java.lang.reflect.InvocationTargetException;
 
 import de.robv.android.xposed.IXposedHookLoadPackage;
 import de.robv.android.xposed.XC_MethodHook;
+import de.robv.android.xposed.XposedBridge;
 import de.robv.android.xposed.XposedHelpers;
 import de.robv.android.xposed.callbacks.XC_LoadPackage;
 import fansirsqi.xposed.sesame.BuildConfig;
@@ -135,6 +139,28 @@ public class ApplicationHook implements IXposedHookLoadPackage {
     }
 
 
+    private final static Method deoptimizeMethod;
+
+    static {
+        Method m = null;
+        try {
+            m = XposedBridge.class.getDeclaredMethod("deoptimizeMethod", Member.class);
+        } catch (Throwable t) {
+            XposedBridge.log("E/" + TAG + " " + android.util.Log.getStackTraceString(t));
+        }
+        deoptimizeMethod = m;
+    }
+
+    static void deoptimizeMethod(Class<?> c, String n) throws InvocationTargetException, IllegalAccessException {
+        for (Method m : c.getDeclaredMethods()) {
+            if (deoptimizeMethod != null && m.getName().equals(n)) {
+                deoptimizeMethod.invoke(null, m);
+                if (BuildConfig.DEBUG)
+                    XposedBridge.log("D/" + TAG + " Deoptimized " + m.getName());
+            }
+        }
+    }
+
     /**
      * 调度定时执行
      *
@@ -210,6 +236,14 @@ public class ApplicationHook implements IXposedHookLoadPackage {
                 if (hooked) return;
                 appLloadPackageParam = loadPackageParam;
                 classLoader = appLloadPackageParam.classLoader;
+                // 在Hook Application.attach 之前，先 deoptimize LoadedApk.makeApplicationInner
+                try {
+                    Class<?> loadedApkClass = classLoader.loadClass("android.app.LoadedApk");
+                    deoptimizeMethod(loadedApkClass, "makeApplicationInner");
+                } catch (Throwable t) {
+                    Log.runtime(TAG, "deoptimize makeApplicationInner err:");
+                    Log.printStackTrace(TAG, t);
+                }
                 XposedHelpers.findAndHookMethod(Application.class, "attach", Context.class, new XC_MethodHook() {
                     @Override
                     protected void afterHookedMethod(MethodHookParam param) throws Throwable {

--- a/app/src/main/java/fansirsqi/xposed/sesame/ui/StringDialog.java
+++ b/app/src/main/java/fansirsqi/xposed/sesame/ui/StringDialog.java
@@ -13,6 +13,7 @@ import android.widget.EditText;
 
 import androidx.appcompat.app.AlertDialog;
 import androidx.core.content.ContextCompat;
+import androidx.core.text.HtmlCompat;
 
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
@@ -113,14 +114,8 @@ public class StringDialog {
         showAlertDialog(c, title, msg, "确定");
     }
 
-    @SuppressLint("ObsoleteSdkInt")
     public static void showAlertDialog(Context c, String title, String msg, String positiveButton) {
-        CharSequence parsedMsg;
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            parsedMsg = Html.fromHtml(msg, Html.FROM_HTML_MODE_LEGACY);
-        } else {
-            parsedMsg = Html.fromHtml(msg);
-        }
+        CharSequence parsedMsg = HtmlCompat.fromHtml(msg, HtmlCompat.FROM_HTML_MODE_LEGACY);
 
         AlertDialog alertDialog = new MaterialAlertDialogBuilder(c)
                 .setTitle(title)


### PR DESCRIPTION
一加系更新8月安全补丁后hook会失败,对应日志:
```java
----part 1 start----
[ 2025-08-16T19:09:54.578    10467: 13964: 13964 E/LSPosed-Bridge  ] java.lang.UnsatisfiedLinkError: No implementation found for long org.luckypray.dexkit.DexKitBridge.nativeInitDexKit(java.lang.String) (tried Java_org_luckypray_dexkit_DexKitBridge_nativeInitDexKit and Java_org_luckypray_dexkit_DexKitBridge_nativeInitDexKit__Ljava_lang_String_2) - is the library loaded, e.g. System.loadLibrary?
	at org.luckypray.dexkit.DexKitBridge.nativeInitDexKit(Native Method)
	at org.luckypray.dexkit.DexKitBridge.<init>(SourceFile:4)
	at fansirsqi.xposed.sesame.hook.ApplicationHook$4.afterHookedMethod(SourceFile:66)
	at y.rSYI.b.vrRxUxQsx.vrm.XC_MethodHook.callAfterHookedMethod(Unknown Source:0)
	at I.callback(Unknown Source:343)
	at LSPHooker_.onCreate(Unknown Source:8)
	at android.app.ActivityThread.handleCreateService(ActivityThread.java:5343)
	at android.app.ActivityThread.-$$Nest$mhandleCreateService(Unknown Source:0)
	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2694)
	at com.alipay.stability.workaround.a.a.__handleMessage_stub_private(SourceFile:33)
	at com.alipay.stability.workaround.a.a.handleMessage(Unknown Source:49)
	at android.os.Handler.dispatchMessage(Handler.java:108)
	at android.os.Looper.loopOnce(Looper.java:288)
	at android.os.Looper.loop(Looper.java:393)
	at android.app.ActivityThread.main(ActivityThread.java:9564)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:600)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1010)
```
尽管lsposed-it 7403提供了修复,但是应该有人没进内测,所以提供一个修复方案