### PR TITLE
refactor(AntOcean): 调整黑名单检查逻辑位置

### DIFF
--- a/app/src/main/java/fansirsqi/xposed/sesame/task/antOcean/AntOcean.java
+++ b/app/src/main/java/fansirsqi/xposed/sesame/task/antOcean/AntOcean.java
@@ -687,12 +687,6 @@ public class AntOcean extends ModelTask {
                     String sceneCode = task.getString("sceneCode");
                     String taskType = task.getString("taskType");
                     String taskStatus = task.getString("taskStatus");
-                    // 在处理任何任务前，先检查黑名单
-                    if (badTaskSet.contains(taskTitle)) {
-                        Log.record(TAG, "海洋任务🌊[" + taskTitle + "]已在黑名单中，跳过处理");
-                        continue;
-                    }
-                    
                     if (TaskStatus.FINISHED.name().equals(taskStatus)) {
                         JSONObject joAward = new JSONObject(AntOceanRpcCall.receiveTaskAward(sceneCode, taskType));
                         if (ResChecker.checkRes(TAG, joAward)) {
@@ -702,6 +696,11 @@ public class AntOcean extends ModelTask {
                             Log.error(TAG, "海洋奖励🌊领取失败：" + joAward);
                         }
                     } else if (TaskStatus.TODO.name().equals(taskStatus)) {
+                        // 在处理任何任务前，先检查黑名单
+                        if (badTaskSet.contains(taskTitle)) {
+                            Log.record(TAG, "海洋任务🌊[" + taskTitle + "]已在黑名单中，跳过处理");
+                            continue;
+                        }
                         if (taskTitle.contains("答题")) {
                             answerQuestion();
                         } else {
@@ -737,8 +736,6 @@ public class AntOcean extends ModelTask {
                         
                         GlobalThreadPools.sleepCompat(500);
                     }
-
-
                 }
                 if (!done) break;
             }


### PR DESCRIPTION
将黑名单检查逻辑从任务循环开始移至TODO状态处理中，避免在FINISHED状态领取奖励前跳过清理自己垃圾2次、帮好友清理垃圾、连续来海洋3次等任务的完成领取。