### PR TITLE
庄园修改

### DIFF
--- a/app/src/main/java/fansirsqi/xposed/sesame/hook/ApplicationHook.java
+++ b/app/src/main/java/fansirsqi/xposed/sesame/hook/ApplicationHook.java
@@ -693,9 +693,11 @@ public class ApplicationHook {
                                                 Log.record(TAG, "手动APP触发，已开启");
                                                 TaskRunnerAdapter adapter = new TaskRunnerAdapter();
                                                 adapter.run();
+                                                return;
+                                            } else {
+                                                Log.record(TAG, "手动APP触发，已关闭");
+                                                return;
                                             }
-                                            Log.record(TAG, "手动APP触发，已关闭");
-                                            return;
                                         }
                                     }
 


### PR DESCRIPTION
1.修改handleAutoFeedAnimal()运行时领取奖励的条件，够一次喂食的180g饲料就不用去领取饲料
2.庄园设置里增加“庄园签到忽略饲料量”，因为满饲料情况下签到不会获得饲料奖励，默认true,即不修改设置和原来一样。如修改设置，在14点后也会忽略饲料量进行签到，避免断签 3.小鸡睡觉时不雇佣小鸡
4.小鸡贴贴修改在小鸡厨房前
5.顺便修改了ApplicationHook.kt中“手动APP触发”log的错误，错误为：如果开启了手动触发支付宝运行，还是会出现“手动APP触发，已关闭”的log。