### PR TITLE
日志和包导入异常

### DIFF
--- a/app/src/main/java/fansirsqi/xposed/sesame/newui/WaterMark.kt
+++ b/app/src/main/java/fansirsqi/xposed/sesame/newui/WaterMark.kt
@@ -1,4 +1,4 @@
-package fansirsqi.xposed.sesame.ui.components
+package fansirsqi.xposed.sesame.newui
 
 import android.graphics.Paint
 import androidx.compose.foundation.Canvas

--- a/app/src/main/java/fansirsqi/xposed/sesame/task/antOrchard/AntOrchard.kt
+++ b/app/src/main/java/fansirsqi/xposed/sesame/task/antOrchard/AntOrchard.kt
@@ -732,15 +732,14 @@ class AntOrchard : ModelTask() {
                             repeat(need) { index ->
                                 val wua = SecurityBodyHelper.getSecurityBodyData(4).toString()
                                 val spreadResult = AntOrchardRpcCall.orchardSpreadManure(wua, "ch_appcenter__chsub_9patch")
-                                Log.record(TAG, "施肥第 ${index + 1} 次结果：$spreadResult")
-
                                 val resultJson = JSONObject(spreadResult)
                                 val resultCode = resultJson.optString("resultCode", "")
                                 val resultDesc = resultJson.optString("resultDesc", "")
-
                                 if (resultCode != "100") {
                                     Log.error(TAG, "农场 orchardSpreadManure 错误：$resultDesc")
                                     return   // ❗施肥失败直接退出整个 limitedTimeChallenge()
+                                } else{
+                                    Log.record(TAG, "施肥第 ${index + 1} 次结果：$resultDesc")
                                 }
                             }
 

--- a/app/src/main/java/fansirsqi/xposed/sesame/ui/MainActivity.kt
+++ b/app/src/main/java/fansirsqi/xposed/sesame/ui/MainActivity.kt
@@ -83,9 +83,9 @@ import fansirsqi.xposed.sesame.SesameApplication.Companion.preferencesKey
 import fansirsqi.xposed.sesame.entity.UserEntity
 import fansirsqi.xposed.sesame.newui.DeviceInfoCard
 import fansirsqi.xposed.sesame.newui.DeviceInfoUtil
+import fansirsqi.xposed.sesame.newui.WatermarkLayer
 import fansirsqi.xposed.sesame.newutil.IconManager
 import fansirsqi.xposed.sesame.ui.MainViewModel.Companion.verifyId
-import fansirsqi.xposed.sesame.ui.components.WatermarkLayer
 import fansirsqi.xposed.sesame.ui.log.LogViewerComposeActivity
 import fansirsqi.xposed.sesame.ui.theme.AppTheme
 import fansirsqi.xposed.sesame.util.Detector
@@ -115,7 +115,8 @@ class MainActivity : BaseActivity() {
         super.onCreate(savedInstanceState)
 
         // 1. 检查权限并初始化逻辑
-        if (PermissionUtil.checkOrRequestFilePermissions(this)) {
+        hasPermissions = PermissionUtil.checkOrRequestFilePermissions(this)
+        if (hasPermissions) {
             viewModel.initAppLogic()
             // 🔥 修复：Native 检测必须在 Activity 中调用
             initNativeDetector()
@@ -150,7 +151,6 @@ class MainActivity : BaseActivity() {
                     )
                 }
             }
-
         }
 
 //        WatermarkView.install(activity = this)

--- a/app/src/main/java/fansirsqi/xposed/sesame/ui/WebSettingsActivity.java
+++ b/app/src/main/java/fansirsqi/xposed/sesame/ui/WebSettingsActivity.java
@@ -235,7 +235,7 @@ public class WebSettingsActivity extends BaseActivity {
         public String getTabs() {
             String result = JsonUtil.formatJson(tabList, false);
             if (BuildConfig.DEBUG) {
-                Log.record(TAG, "WebSettingsActivity.getTabs: " + result);
+//                Log.record(TAG, "WebSettingsActivity.getTabs: " + result);
             }
             return result;
         }
@@ -258,7 +258,7 @@ public class WebSettingsActivity extends BaseActivity {
         public String getGroup() {
             String result = JsonUtil.formatJson(groupList, false);
             if (BuildConfig.DEBUG) {
-                Log.record(TAG, "WebSettingsActivity.getGroup: " + result);
+//                Log.record(TAG, "WebSettingsActivity.getGroup: " + result);
             }
             return result;
         }
@@ -276,7 +276,7 @@ public class WebSettingsActivity extends BaseActivity {
             }
             String result = JsonUtil.formatJson(modelDtoList, false);
             if (BuildConfig.DEBUG) {
-                Log.record(TAG, "WebSettingsActivity.getModelByGroup: " + result);
+//                Log.record(TAG, "WebSettingsActivity.getModelByGroup: " + result);
             }
             return result;
         }
@@ -316,7 +316,7 @@ public class WebSettingsActivity extends BaseActivity {
                 }
                 String result = JsonUtil.formatJson(list, false);
                 if (BuildConfig.DEBUG) {
-                    Log.record(TAG, "WebSettingsActivity.getModel: " + result);
+//                    Log.record(TAG, "WebSettingsActivity.getModel: " + result);
                 }
                 return result;
             }
@@ -363,7 +363,7 @@ public class WebSettingsActivity extends BaseActivity {
                 if (modelField != null) {
                     String result = JsonUtil.formatJson(ModelFieldInfoDto.toInfoDto(modelField), false);
                     if (BuildConfig.DEBUG) {
-                        Log.record(TAG, "WebSettingsActivity.getField: " + result);
+//                        Log.record(TAG, "WebSettingsActivity.getField: " + result);
                     }
                     return result;
                 }

--- a/app/src/main/java/fansirsqi/xposed/sesame/ui/compose/WatermarkInjector.kt
+++ b/app/src/main/java/fansirsqi/xposed/sesame/ui/compose/WatermarkInjector.kt
@@ -6,7 +6,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
-import fansirsqi.xposed.sesame.ui.components.WatermarkLayer
+import fansirsqi.xposed.sesame.newui.WatermarkLayer
 import fansirsqi.xposed.sesame.ui.theme.AppTheme
 
 /**

--- a/app/src/main/java/fansirsqi/xposed/sesame/ui/log/LogViewerComposeActivity.kt
+++ b/app/src/main/java/fansirsqi/xposed/sesame/ui/log/LogViewerComposeActivity.kt
@@ -3,7 +3,7 @@ package fansirsqi.xposed.sesame.ui.log
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import fansirsqi.xposed.sesame.ui.components.WatermarkLayer
+import fansirsqi.xposed.sesame.newui.WatermarkLayer
 import fansirsqi.xposed.sesame.ui.theme.AppTheme
 
 //import fansirsqi.xposed.sesame.newui.WatermarkView


### PR DESCRIPTION
1.MainActivity()中为hasPermissions赋值，使onResume()中的方法正确运行。修复软件可以正常运行时首页还是显示“用户未载入” 
2.WatermarkLayer方法import路径已经变更到newui中了
3.修复果园施肥时Log打印完整json文件的问题，现在仅显示$resultDesc
4.注释掉WebSettingsActivity()方法中直接打印原始json的Log.record 
5.3和4的Log.record打印原始数据巨大，导致日志查看卡顿
6.除了1和3的修改有点必要，其他修改管理根据自己重构log的计划决定吧。这是临时的。